### PR TITLE
feat: Implement basic frontend for Network Connectivity Tester

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Network Connectivity Tester</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Network Connectivity Tester</h1>
+
+        <div class="form-group">
+            <label for="source">Source (Kubernetes Cluster Name):</label>
+            <input type="text" id="source" name="source" placeholder="e.g., my-cluster">
+        </div>
+
+        <div class="form-group">
+            <label for="destinations">Destinations (comma-separated or new line):</label>
+            <textarea id="destinations" name="destinations" rows="5" placeholder="e.g., google.com, 8.8.8.8, internal-service:8080"></textarea>
+        </div>
+
+        <div class="form-group">
+            <label for="prepopulated-destinations">Or select from prepopulated list:</label>
+            <select id="prepopulated-destinations" name="prepopulated-destinations" multiple>
+                <!-- Options will be populated by script.js -->
+            </select>
+        </div>
+
+        <button id="test-button">Test Connectivity</button>
+
+        <div class="results">
+            <h2>Results:</h2>
+            <pre id="results-output"></pre>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const sourceInput = document.getElementById('source');
+    const destinationsTextarea = document.getElementById('destinations');
+    const prepopulatedDestsSelect = document.getElementById('prepopulated-destinations');
+    const testButton = document.getElementById('test-button');
+    const resultsOutput = document.getElementById('results-output');
+
+    // Sample prepopulated destinations (replace with actual data source if available)
+    const samplePrepopulatedDests = [
+        { name: "Google DNS", address: "8.8.8.8" },
+        { name: "Cloudflare DNS", address: "1.1.1.1" },
+        { name: "Example.com", address: "example.com" },
+        { name: "Internal Service A (Prod)", address: "service-a.prod.svc.cluster.local:8080" },
+        { name: "Internal Service B (Dev)", address: "service-b.dev.svc.cluster.local:3000" }
+    ];
+
+    // Populate prepopulated destinations
+    function populatePrepopulatedDestinations() {
+        samplePrepopulatedDests.forEach(dest => {
+            const option = document.createElement('option');
+            option.value = dest.address;
+            option.textContent = `${dest.name} (${dest.address})`;
+            prepopulatedDestsSelect.appendChild(option);
+        });
+    }
+
+    populatePrepopulatedDestinations();
+
+    testButton.addEventListener('click', async () => {
+        const source = sourceInput.value.trim();
+        const manualDestinations = destinationsTextarea.value.trim().split(/[\s,]+/).filter(Boolean);
+        const selectedPrepopulated = Array.from(prepopulatedDestsSelect.selectedOptions).map(option => option.value);
+
+        const allDestinations = [...new Set([...manualDestinations, ...selectedPrepopulated])]; // Combine and remove duplicates
+
+        if (!source) {
+            resultsOutput.textContent = "Error: Source (Kubernetes Cluster Name) cannot be empty.";
+            return;
+        }
+
+        if (allDestinations.length === 0) {
+            resultsOutput.textContent = "Error: Please provide at least one destination.";
+            return;
+        }
+
+        resultsOutput.textContent = "Testing connectivity...\n";
+        resultsOutput.textContent += `Source: ${source}\n`;
+        resultsOutput.textContent += `Destinations: ${allDestinations.join(', ')}\n\n`;
+
+        // Placeholder for actual backend API call
+        // For now, simulate results after a delay
+
+        // Simulate API call and display mock results
+        // In a real application, this would be an asynchronous call to a backend API
+        // e.g., const response = await fetch('/api/test-connectivity', { /* ... */ });
+        // const data = await response.json();
+        // displayResults(data);
+
+        resultsOutput.textContent += "Simulating backend call...\n";
+        await new Promise(resolve => setTimeout(resolve, 1500)); // Simulate network delay
+
+        const mockResults = allDestinations.map(dest => {
+            const isSuccess = Math.random() > 0.3; // Simulate success/failure
+            return {
+                destination: dest,
+                status: isSuccess ? "SUCCESS" : "FAILED",
+                details: isSuccess ? "Connection successful." : "Connection timed out."
+            };
+        });
+
+        displayResults(mockResults, source);
+    });
+
+    function displayResults(results, sourceCluster) {
+        resultsOutput.textContent = `Connectivity Test Results from ${sourceCluster}:\n\n`;
+        if (results.length === 0) {
+            resultsOutput.textContent += "No results to display.";
+            return;
+        }
+        results.forEach(result => {
+            resultsOutput.textContent += `Destination: ${result.destination}\n`;
+            resultsOutput.textContent += `Status: ${result.status}\n`;
+            resultsOutput.textContent += `Details: ${result.details}\n\n`;
+        });
+    }
+
+    // Allow users to add destinations from select to textarea by double clicking
+    prepopulatedDestsSelect.addEventListener('dblclick', () => {
+        const selectedValues = Array.from(prepopulatedDestsSelect.selectedOptions).map(option => option.value);
+        if (selectedValues.length > 0) {
+            const currentTextDests = destinationsTextarea.value.trim().split(/[\s,]+/).filter(Boolean);
+            const newDests = [...new Set([...currentTextDests, ...selectedValues])];
+            destinationsTextarea.value = newDests.join('\n');
+        }
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,91 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    background-color: #f4f4f4;
+    color: #333;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.container {
+    background-color: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
+    width: 100%;
+    max-width: 600px;
+}
+
+h1 {
+    text-align: center;
+    color: #0056b3;
+    margin-bottom: 20px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: bold;
+}
+
+.form-group input[type="text"],
+.form-group textarea,
+.form-group select {
+    width: calc(100% - 22px); /* Account for padding and border */
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box; /* Include padding and border in the element's total width and height */
+}
+
+.form-group textarea {
+    resize: vertical; /* Allow vertical resizing */
+}
+
+.form-group select[multiple] {
+    min-height: 100px; /* Provide a decent default height for multi-select */
+}
+
+button {
+    display: block;
+    width: 100%;
+    padding: 12px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+.results {
+    margin-top: 30px;
+    border-top: 1px solid #eee;
+    padding-top: 20px;
+}
+
+.results h2 {
+    color: #0056b3;
+    margin-bottom: 10px;
+}
+
+.results pre {
+    background-color: #e9e9e9;
+    padding: 15px;
+    border-radius: 4px;
+    white-space: pre-wrap; /* Wrap long lines */
+    word-wrap: break-word; /* Break long words */
+    min-height: 50px;
+    border: 1px solid #ccc;
+}


### PR DESCRIPTION
This commit introduces the initial frontend structure and functionality for the Network Connectivity Tester tool.

It includes:
- An HTML page (`index.html`) with input fields for source (Kubernetes cluster name) and destinations (manual input textarea and a prepopulated select list).
- CSS styling (`style.css`) for a user-friendly layout and appearance.
- JavaScript logic (`script.js`) to:
    - Populate a sample list of prepopulated destinations.
    - Handle your input and combine destinations from both manual input and the prepopulated list.
    - Validate that source and destination inputs are not empty.
    - Simulate a connectivity test by displaying mock results after a short delay (actual backend integration is pending).
    - Allow you to add destinations from the select list to the textarea by double-clicking an option.

The frontend provides a basic interface for you to specify test parameters and view (currently simulated) results.