### PR TITLE
fix: Improve robustness of parsing pre-selected-destinations.txt

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(`HTTP error! status: ${response.status} while fetching pre-selected-destinations.txt`);
             }
             const data = await response.text();
-            const lines = data.trim().split('\n'); // Split by newline characters
+            const lines = data.trim().split(/\r?\n/); // Split by newline characters
 
             if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {
                 console.warn('pre-selected-destinations.txt is empty or contains only whitespace.');


### PR DESCRIPTION
I modified `script.js` to handle both LF (Unix/macOS) and CRLF (Windows) line endings when splitting the content of `pre-selected-destinations.txt` into lines.

The line splitting logic in `populatePrepopulatedDestinations` was changed from `data.trim().split('\n')` to `data.trim().split(/\r?\n/)`. This ensures that the prepopulated destinations are loaded correctly regardless of the line ending format used in the text file.