### PR TITLE
fix: Enable CORS on backend and update frontend API URL

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,9 @@
 import os
 from flask import Flask, jsonify, current_app
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app) # This will enable CORS for all routes and origins by default
 
 # Configuration for the destinations file path
 # Assumes pre-selected-destinations.txt is in the same directory as app.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+Flask-CORS

--- a/script.js
+++ b/script.js
@@ -12,9 +12,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Populate prepopulated destinations
     async function populatePrepopulatedDestinations() {
         try {
-            const response = await fetch('/api/destinations'); // Changed URL
+            const response = await fetch('http://localhost:5000/api/destinations'); // Changed URL
             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status} while fetching /api/destinations`);
+                throw new Error(`HTTP error! status: ${response.status} while fetching http://localhost:5000/api/destinations`);
             }
 
             const destinations = await response.json(); // Get JSON data


### PR DESCRIPTION
This commit addresses issues with fetching prepopulated destinations when the frontend and backend are served on different ports during local development.

Changes:

1.  **Backend (`backend/`):**
    *   Added `Flask-CORS` to `requirements.txt`.
    *   Modified `app.py` to import `CORS` from `flask_cors` and
      initialize it with the Flask app (`CORS(app)`). This enables
      Cross-Origin Resource Sharing, allowing the backend to accept
      requests from the frontend's origin (e.g., http://localhost:8000).

2.  **Frontend (`script.js`):**
    *   Updated the `fetch` call in `populatePrepopulatedDestinations`
      to use the absolute URL for the backend API:
      `http://localhost:5000/api/destinations`. This ensures the
      frontend explicitly targets the backend server.

These changes allow the frontend to correctly communicate with the backend API across different ports.