### PR TITLE
feat: Implement Phase 2 - Backend for mock test execution

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 import os
-from flask import Flask, jsonify, current_app
+import random # Added import
+from flask import Flask, jsonify, current_app, request # Added request
 from flask_cors import CORS
 
 app = Flask(__name__)
@@ -47,6 +48,52 @@ def get_destinations():
     except Exception as e:
         current_app.logger.error(f"Error reading or parsing destinations file: {e}")
         return jsonify({"error": "An error occurred while processing destinations on the server."}), 500
+
+@app.route('/api/test-connectivity', methods=['POST'])
+def test_connectivity():
+    """
+    API endpoint to simulate network connectivity tests.
+    Expects JSON: { "source": "cluster-name", "destinations": ["dest1", "dest2"] }
+    Returns JSON results.
+    """
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No input data provided"}), 400
+
+        source = data.get('source')
+        destinations = data.get('destinations')
+
+        if not source:
+            return jsonify({"error": "Missing 'source' in request"}), 400
+        if not destinations or not isinstance(destinations, list) or len(destinations) == 0:
+            return jsonify({"error": "Missing or invalid 'destinations' list in request"}), 400
+
+        current_app.logger.info(f"Received test request from source: {source} for destinations: {', '.join(destinations)}")
+
+        # Simulate test results
+        mock_results = []
+        for dest in destinations:
+            # Simulate some processing time per destination
+            # import time # Add this if you uncomment the sleep
+            # time.sleep(random.uniform(0.1, 0.5))
+
+            is_success = random.choice([True, False, True]) # Skew towards success for mock
+            status = "SUCCESS" if is_success else "FAILED"
+            details = "Connection successful." if is_success else "Connection timed out (simulated)."
+
+            mock_results.append({
+                "destination": dest,
+                "status": status,
+                "details": details
+            })
+
+        current_app.logger.info(f"Simulated results: {mock_results}")
+        return jsonify(mock_results), 200
+
+    except Exception as e:
+        current_app.logger.error(f"Error in /api/test-connectivity: {e}")
+        return jsonify({"error": "An error occurred on the server during test execution."}), 500
 
 if __name__ == '__main__':
     # Note: For development only. Use a proper WSGI server for production.


### PR DESCRIPTION
This commit introduces the backend infrastructure for handling connectivity test requests, with mock execution logic for now. The frontend has been updated to call this backend endpoint.

Changes:

1.  **Backend (`backend/app.py`):**
    *   Added a new POST endpoint `/api/test-connectivity`.
    *   This endpoint expects a JSON payload containing `source` (string)
      and `destinations` (list of strings).
    *   It performs input validation on the received data.
    *   Currently, it *simulates* network tests by generating mock
      "SUCCESS" or "FAILED" results for each destination.
    *   Returns these mock results as a JSON array.
    *   Ensured `random` and `request` (from Flask) are imported.

2.  **Frontend (`script.js`):**
    *   The `testButton` event listener has been significantly modified:
        *   Removed the previous client-side mock result generation.
        *   It now makes a `fetch` POST request to the new
          `http://localhost:5000/api/test-connectivity` backend endpoint.
        *   The `source` and `destinations` are sent as a JSON payload.
        *   The JSON response from the backend (containing the mock test
          results) is then passed to the existing `displayResults`
          function for rendering in the UI.
        *   UI state (loading messages, error messages) is updated
          during the API call.

This completes the setup for backend-driven test execution. The next step will be to replace the mock logic in the backend with actual network test implementations.