### PR TITLE
fix: Update Go version in tester-agent Dockerfile

### DIFF
--- a/tester-agent/Dockerfile
+++ b/tester-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.21-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
I've changed the Go builder image in `tester-agent/Dockerfile` from `golang:1.21-alpine` to `golang:1.22-alpine`.

This addresses a Docker build error caused by the `go.mod` file requiring a newer Go version than was present in the previous builder image. Updating to `golang:1.22-alpine` ensures compatibility for the `go mod download` step.