### PR TITLE
fix: Update Go version in tester-agent Dockerfile to latest alpine

### DIFF
--- a/tester-agent/Dockerfile
+++ b/tester-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22-alpine AS builder
+FROM golang:alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
I changed the Go builder image in `tester-agent/Dockerfile` to `FROM golang:alpine AS builder`.

This addresses a Docker build error where your `go.mod` file required Go >= 1.24.3, and previous explicit Go versions (1.21, 1.22) in the Dockerfile were too old. Using `golang:alpine` ensures that the latest stable Go version available on Alpine is used, which should satisfy the `go.mod` requirement.