### PR TITLE
Okay, I've updated the Docker image name for the tester-agent.

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -100,7 +100,7 @@ def test_connectivity():
     # source_cluster_context = data.get('source') # Removed
     destinations = data.get('destinations')
     namespace = "application"
-    docker_image = "docker.jamealwi2.io/tester-agent:beta.0"
+    docker_image = "docker.branch.io/tester-agent:beta.0"
 
     # if not source_cluster_context: # Removed validation
     #     return jsonify({"error": "Missing 'source' (kubectl context) in request"}), 400


### PR DESCRIPTION
I changed the hardcoded Docker image name in `backend/app.py` from `docker.jamealwi2.io/tester-agent:beta.0` to `docker.branch.io/tester-agent:beta.0` based on your feedback.

This affects the image used when the backend dynamically creates Kubernetes Jobs for connectivity testing.