### PR TITLE
feat: Add Execution Details section and update label in frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         </div>
 
         <div class="form-group">
-            <label for="prepopulated-destinations">Or select from prepopulated list:</label>
+            <label for="prepopulated-destinations">Test Destination:</label>
             <select id="prepopulated-destinations" name="prepopulated-destinations" multiple>
                 <!-- Options will be populated by script.js -->
             </select>
@@ -30,6 +30,15 @@
         <button id="test-button">Test Connectivity</button>
 
         <div class="results">
+            <div class="test-run-details">
+                <details>
+                    <summary>Execution Details</summary>
+                    <div>
+                        <p><strong>Kubernetes Job Name:</strong> <span id="k8s-job-name">-</span></p>
+                        <p><strong>Kubernetes Pod Name(s):</strong> <span id="k8s-pod-names">-</span></p>
+                    </div>
+                </details>
+            </div>
             <div id="celebration-banner" class="hidden"></div>
             <h2>Successful Connections:</h2>
             <div id="successful-results" class="results-category">


### PR DESCRIPTION
This commit introduces changes to display Kubernetes Job and Pod information for each test run in the frontend, and updates a UI label.

Modifications:

1.  **`index.html`**:
    *   Changed the label for the prepopulated destinations dropdown from
      "Or select from prepopulated list:" to "Test Destination:".
    *   Added a new collapsible "Execution Details" section. This section includes placeholders
      to display the Kubernetes Job name and Pod name(s).

2.  **`backend/app.py` (`/api/test-connectivity` endpoint):**
    *   The `fetch_job_logs` helper function was modified to return both
      the logs and the determined Pod name.
    *   The main endpoint now structures its JSON response to include:
        -   `results`: The array of test outcomes.
        -   `metadata`: An object containing `kubernetesJobName` (string)
          and `kubernetesPodNames` (list of strings).
    *   Metadata (specifically `kubernetesJobName`) is also included
      in the JSON response for failed jobs if logs are retrieved.

3.  **`script.js` (frontend):**
    *   Added DOM references for the new "Execution Details" elements.
    *   The `testButton` event listener now clears/resets these details
      on new test initiation and handles the new backend response structure.
    *   A new `handleTestResponse` function was introduced to:
        -   Parse the wrapped response from the backend.
        -   Populate the "Execution Details" section with Job and Pod names
          from the `metadata` field.
        -   Control the visibility of the "Execution Details" section.
        -   Pass the actual test `results` array to the existing
          `displayResults` function.

These changes enhance the frontend by providing you with more context about the underlying Kubernetes resources used for test execution.