### PR TITLE
feat: Display individual connection durations

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,12 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // Populate prepopulated destinations
     async function populatePrepopulatedDestinations() {
         try {
-            const response = await fetch('http://localhost:5000/api/destinations'); 
+            const response = await fetch('http://localhost:5000/api/destinations');
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status} while fetching http://localhost:5000/api/destinations`);
             }
-            
-            const destinations = await response.json(); 
+
+            const destinations = await response.json();
 
             if (!destinations || destinations.length === 0) {
                 console.warn('No prepopulated destinations received from API or API returned empty list.');
@@ -41,10 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
         } catch (error) {
-            console.error('Error fetching prepopulated destinations from API:', error); 
+            console.error('Error fetching prepopulated destinations from API:', error);
             prepopulatedDestsSelect.innerHTML = '<option value="">Error loading destinations</option>';
             if (noResultsMessage) {
-                noResultsMessage.textContent = 'Could not load prepopulated destinations from the backend. Please ensure the backend server is running and check console for details.'; 
+                noResultsMessage.textContent = 'Could not load prepopulated destinations from the backend. Please ensure the backend server is running and check console for details.';
                 noResultsMessage.classList.remove('hidden');
             }
         }
@@ -57,17 +57,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const manualDestinations = destinationsTextarea.value.trim().split(/[\s,]+/).filter(Boolean);
         const selectedPrepopulated = Array.from(prepopulatedDestsSelect.selectedOptions).map(option => option.value);
 
-        const allDestinations = [...new Set([...manualDestinations, ...selectedPrepopulated])]; 
+        const allDestinations = [...new Set([...manualDestinations, ...selectedPrepopulated])];
 
         successfulResultsDiv.innerHTML = '';
         failedResultsDiv.innerHTML = '';
         celebrationBanner.classList.add('hidden');
         celebrationBanner.textContent = '';
         noResultsMessage.classList.add('hidden');
-        
+
         if (k8sJobNameSpan) k8sJobNameSpan.textContent = '-';
         if (k8sPodNamesSpan) k8sPodNamesSpan.textContent = '-';
         if (executionDetailsSection) executionDetailsSection.open = false;
+
 
         if (!source) {
             noResultsMessage.textContent = "Error: Source (Kubernetes Cluster Name) cannot be empty. This is a mock field for now.";
@@ -80,9 +81,9 @@ document.addEventListener('DOMContentLoaded', () => {
             noResultsMessage.classList.remove('hidden');
             return;
         }
-        
+
         successfulResultsDiv.innerHTML = `<p>Requesting tests from backend for destinations: ${allDestinations.join(', ')}...</p>`;
-        
+
         try {
             const response = await fetch('http://localhost:5000/api/test-connectivity', {
                 method: 'POST',
@@ -110,8 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         } catch (error) {
             console.error('Error during connectivity test:', error);
-            failedResultsDiv.innerHTML = ''; 
-            successfulResultsDiv.innerHTML = ''; 
+            failedResultsDiv.innerHTML = '';
+            successfulResultsDiv.innerHTML = '';
             noResultsMessage.textContent = `Error during connectivity test: ${error.message}. Please check the console for more details. Ensure the backend is running and reachable.`;
             noResultsMessage.classList.remove('hidden');
             celebrationBanner.classList.add('hidden');
@@ -137,9 +138,9 @@ document.addEventListener('DOMContentLoaded', () => {
         displayResults(resultsForDisplay, sourceCluster);
     }
 
-    function displayResults(results, sourceCluster) { 
+    function displayResults(results, sourceCluster) {
         console.log("[DEBUG] Entering displayResults. Received results:", results, "Type of results:", typeof results, "Is Array:", Array.isArray(results), "sourceCluster:", sourceCluster);
-        successfulResultsDiv.innerHTML = ''; 
+        successfulResultsDiv.innerHTML = '';
         failedResultsDiv.innerHTML = '';
         celebrationBanner.classList.add('hidden');
         celebrationBanner.textContent = '';
@@ -152,11 +153,6 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         } else {
             noResultsMessage.classList.add('hidden');
-            successfulResultsDiv.innerHTML = '<p>None</p>'; 
-            failedResultsDiv.innerHTML = '<p>None</p>';   
-            return;
-        } else {
-            noResultsMessage.classList.add('hidden'); 
         }
 
         let failedCount = 0;
@@ -165,9 +161,16 @@ document.addEventListener('DOMContentLoaded', () => {
         results.forEach(result => {
             const resultElement = document.createElement('div');
             resultElement.classList.add('result-item');
+
+            let durationHtml = '';
+            if (result.duration) {
+                durationHtml = `<p><strong>Duration:</strong> ${result.duration}</p>`;
+            }
+
             resultElement.innerHTML = `
                 <p><strong>Destination:</strong> ${result.destination}</p>
                 <p><strong>Status:</strong> <span class="status-${result.status.toLowerCase()}">${result.status}</span></p>
+                ${durationHtml}
                 <p><strong>Details:</strong> ${result.details}</p>
             `;
             if (result.status === "SUCCESS") {
@@ -185,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (failedCount === 0 && results.length > 0) {
             failedResultsDiv.innerHTML = '<p>No failed connections.</p>';
         }
-        
+
         if (failedCount === 0 && successCount > 0) {
             celebrationBanner.textContent = `🎉 Hooray! All ${successCount} connection(s) from the cluster were successful! 🎉`;
             celebrationBanner.classList.remove('hidden');


### PR DESCRIPTION
This commit introduces functionality to measure and display the duration for each individual network test.

Changes:

1.  **`tester-agent/main.go` (Go Tester Agent):**
    *   The `DestinationTestResult` struct now includes a `Duration`
      field (string, e.g., "123ms"), tagged as `json:"duration,omitempty"`.
    *   The `performTCPCheck` and `performHTTPGetCheck` functions were
      updated to:
        - Measure the time taken for their core network operations
          (e.g., `net.DialTimeout`, `client.Get`).
        - Format this duration into a millisecond string.
        - Return the duration string along with status and details.
    *   The main loop was updated to incorporate this duration into
      the `DestinationTestResult` objects.

2.  **`script.js` (Frontend):**
    *   The `displayResults` function was modified.
    *   When rendering each test result item, it now checks for a
      `result.duration` property.
    *   If present, a new line displaying "Duration: [value]" is
      added to the item's HTML output.

This allows you to see how long each specific TCP connection or HTTP GET request took from the perspective of the tester agent running in the Kubernetes cluster. The backend `app.py` did not require changes as it already passes through the agent's JSON output.

Note: The `tester-agent` Docker image (`docker.branch.io/tester-agent:beta.0`) will need to be rebuilt and pushed with the Go agent changes for this feature to be effective.