### PR TITLE
feat: Re-add explicit Kubernetes context handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,6 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
+                    source: source, // Ensure this line is present and not commented
                     destinations: allDestinations
                 }),
             });
@@ -159,11 +160,14 @@ document.addEventListener('DOMContentLoaded', () => {
         let successCount = 0;
 
         results.forEach(result => {
+            console.log("[DEBUG] Loop item - result object:", result); // ENSURE THIS IS THE FIRST LINE
             const resultElement = document.createElement('div');
             resultElement.classList.add('result-item');
 
             let durationHtml = '';
-            if (result.duration) {
+            // Ensure result.duration is a non-empty string before displaying.
+            // The Go agent sends "0ms" or "XXms", which are truthy.
+            if (result.duration && result.duration.trim() !== "") {
                 durationHtml = `<p><strong>Duration:</strong> ${result.duration}</p>`;
             }
 


### PR DESCRIPTION
This commit re-introduces the functionality for specifying a Kubernetes context for `kubectl` operations, passed from the frontend to the backend.

Changes:

1.  **`backend/app.py`:**
    *   The `/api/test-connectivity` endpoint now retrieves a `source`
      field from the JSON request body, which is used as the
      `--context` argument for all `kubectl` commands.
    *   Validation for the `source` field has been re-added.
    *   The `fetch_job_logs` helper function was updated to accept and
      use the `context` parameter.
    *   Associated logging messages were updated to include context info.

2.  **`script.js` (Frontend):**
    *   The `testButton` event listener now includes the `source` value
      (from the "Source (Kubernetes Cluster Name)" input field) in the
      JSON payload sent to the `/api/test-connectivity` backend endpoint.

This allows you to specify the target Kubernetes cluster context for test execution via the UI, instead of the backend relying on its ambient `kubectl` context.