### PR TITLE
feat: Containerize frontend using Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Use nginx alpine for a lightweight image
+FROM nginx:alpine
+
+# Copy static frontend files to the default nginx webroot directory
+COPY index.html /usr/share/nginx/html/
+COPY script.js /usr/share/nginx/html/
+COPY style.css /usr/share/nginx/html/
+
+# Nginx by default listens on port 80
+EXPOSE 80
+
+# Default command to start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/script.js
+++ b/script.js
@@ -16,9 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Populate prepopulated destinations
     async function populatePrepopulatedDestinations() {
         try {
-            const response = await fetch('http://localhost:5000/api/destinations');
+            const response = await fetch('http://host.docker.internal:5000/api/destinations');
             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status} while fetching http://localhost:5000/api/destinations`);
+                throw new Error(`HTTP error! status: ${response.status} while fetching http://host.docker.internal:5000/api/destinations`);
             }
 
             const destinations = await response.json();
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
         successfulResultsDiv.innerHTML = `<p>Requesting tests from backend for destinations: ${allDestinations.join(', ')}...</p>`;
 
         try {
-            const response = await fetch('http://localhost:5000/api/test-connectivity', {
+            const response = await fetch('http://host.docker.internal:5000/api/test-connectivity', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
This commit introduces a Dockerfile to containerize the frontend application (HTML, CSS, JS) using Nginx. It also updates `script.js` to use `host.docker.internal` for API calls to support Docker Desktop environments, and updates the README accordingly.

Changes:

1.  **`Dockerfile` (New, in project root):**
    *   Added a new Dockerfile that uses `nginx:alpine`.
    *   Copies `index.html`, `script.js`, and `style.css` into the
      Nginx webroot (`/usr/share/nginx/html/`).
    *   Exposes port 80.

2.  **`script.js`:**
    *   Modified all API `fetch` calls (for `/api/destinations` and
      `/api/test-connectivity`) to target
      `http://host.docker.internal:5000` instead of
      `http://localhost:5000`. This enables the containerized frontend
      on Docker Desktop (Mac/Windows) to reach the backend running on
      the host.

3.  **`README.md`:**
    *   Added a new "Frontend Setup (Option 2: Using a Docker Container)"
      section with instructions on how to build and run the new
      frontend Docker image (e.g., `docker build -t ping-patrol-frontend .`
      and `docker run -d -p 8000:80 ping-patrol-frontend`).
    *   Renamed the previous frontend setup to "Option 1".
    *   Included an explanation of why `host.docker.internal` is used
      for Docker Desktop and noted potential considerations for
      Docker on Linux.
    *   Updated the Tester Agent image tag to `vbeta.1` for consistency.

This allows the frontend to be served as a Docker container, simplifying its deployment and ensuring it can communicate with the backend running on the host in common Docker Desktop development setups.