### PR TITLE
feat: Add "Select All" button for prepopulated destinations

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <select id="prepopulated-destinations" name="prepopulated-destinations" multiple>
                 <!-- Options will be populated by script.js -->
             </select>
+            <button type="button" id="select-all-dests-button" style="margin-top: 5px;">Select All</button>
         </div>
 
         <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const executionDetailsSection = document.querySelector('.test-run-details details');
 
     const downloadCsvButton = document.getElementById('download-csv-button');
+    const selectAllDestsButton = document.getElementById('select-all-dests-button');
     let latestTestResults = [];
 
     // Populate prepopulated destinations
@@ -166,11 +167,9 @@ document.addEventListener('DOMContentLoaded', () => {
             noResultsMessage.classList.remove('hidden');
             successfulResultsDiv.innerHTML = '<p>None</p>';
             failedResultsDiv.innerHTML = '<p>None</p>';
-            // downloadCsvButton.classList.add('hidden'); // Already handled in handleTestResponse
             return;
         } else {
             noResultsMessage.classList.add('hidden');
-            // downloadCsvButton.classList.remove('hidden'); // Already handled in handleTestResponse
         }
 
         let failedCount = 0;
@@ -274,6 +273,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (downloadCsvButton) {
         downloadCsvButton.addEventListener('click', downloadResultsCSV);
+    }
+
+    if (selectAllDestsButton && prepopulatedDestsSelect) {
+        selectAllDestsButton.addEventListener('click', () => {
+            for (let i = 0; i < prepopulatedDestsSelect.options.length; i++) {
+                prepopulatedDestsSelect.options[i].selected = true;
+            }
+        });
     }
 
     prepopulatedDestsSelect.addEventListener('dblclick', () => {

--- a/style.css
+++ b/style.css
@@ -191,3 +191,20 @@ button:hover {
 #download-csv-button:hover {
     background-color: #218838; /* Darker green on hover */
 }
+
+/* Select All Destinations Button Styling */
+#select-all-dests-button {
+    background-color: #6c757d; /* A neutral secondary button color */
+    color: white;
+    padding: 6px 12px; /* Smaller padding than main action buttons */
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    margin-top: 8px; /* Consistent margin */
+    display: inline-block;
+}
+
+#select-all-dests-button:hover {
+    background-color: #5a6268; /* Darker on hover */
+}


### PR DESCRIPTION
This commit introduces a "Select All" button to the frontend, allowing you to quickly select all entries in the prepopulated destinations list.

Changes:

1.  **`index.html`**:
    *   Added a new button with id `select-all-dests-button` and text
      "Select All", placed below the prepopulated destinations
      dropdown list.

2.  **`script.js`**:
    *   Added a DOM reference for the new button.
    *   Implemented an event listener for the "Select All" button.
      When clicked, this listener iterates through all options in the
      prepopulated destinations `<select>` element and sets their
      `selected` property to `true`.

3.  **`style.css`**:
    *   Added basic styling for the `#select-all-dests-button` to give
      it a distinct, secondary appearance and appropriate spacing.

This feature improves the usability of selecting multiple prepopulated destinations for testing.