### PR TITLE
feat: Enhance "Select All" to also populate textarea

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,11 +275,27 @@ document.addEventListener('DOMContentLoaded', () => {
         downloadCsvButton.addEventListener('click', downloadResultsCSV);
     }
 
-    if (selectAllDestsButton && prepopulatedDestsSelect) {
+    if (selectAllDestsButton && prepopulatedDestsSelect && destinationsTextarea) { // Added destinationsTextarea check
         selectAllDestsButton.addEventListener('click', () => {
+            const allPrepopulatedValues = [];
             for (let i = 0; i < prepopulatedDestsSelect.options.length; i++) {
                 prepopulatedDestsSelect.options[i].selected = true;
+                // Collect all values from the prepopulated list, as they are all now selected
+                if (prepopulatedDestsSelect.options[i].value) { // Ensure option has a value
+                    allPrepopulatedValues.push(prepopulatedDestsSelect.options[i].value);
+                }
             }
+
+            // Now, update the textarea, similar to the dblclick handler
+            const currentTextDests = destinationsTextarea.value.trim().split(/[\s,]+/).filter(Boolean);
+            // Combine with all values from the prepopulated list, ensuring uniqueness
+            const newDests = [...new Set([...currentTextDests, ...allPrepopulatedValues])];
+            destinationsTextarea.value = newDests.join('\n');
+
+            // Optional: Trigger a change event on prepopulatedDestsSelect if needed by other logic
+            // prepopulatedDestsSelect.dispatchEvent(new Event('change'));
+            // Optional: Trigger an input event on destinationsTextarea if needed
+            // destinationsTextarea.dispatchEvent(new Event('input'));
         });
     }
 


### PR DESCRIPTION
I've updated the "Select All" button functionality in `script.js`. In addition to selecting all options in the prepopulated destinations dropdown, clicking "Select All" now also populates the main "Destinations (comma-separated or new line)" textarea.

The values from the prepopulated list are merged with any existing destinations in the textarea, ensuring uniqueness. Each destination is added on a new line in the textarea.

This makes the "Select All" feature more comprehensive and consistent with your expectations based on the double-click behavior of the dropdown list.